### PR TITLE
fix: source.unsplash.com/random was deprecated in 2024 (now 503s)

### DIFF
--- a/src/interactive/SwrXstate.svelte
+++ b/src/interactive/SwrXstate.svelte
@@ -28,7 +28,7 @@
     return new Promise((resolve, reject) => {
       if (fetchSuccess) {
         // Increment counter to make it a unique URL.
-        let url = `https://source.unsplash.com/random/200x200?q=${counter++}`;
+        let url = `https://picsum.photos/seed/swrxstate-${counter++}/200/200`;
         setTimeout(() => resolve(url), fetchDelay);
       } else {
         setTimeout(() => reject(new Error('Fetch failed!')), fetchDelay);


### PR DESCRIPTION
`src/interactive/SwrXstate.svelte` references the deprecated `source.unsplash.com/random` endpoint, which Unsplash retired in mid-2024 and which now returns HTTP 503 instead of an image.

---

#### Why this is needed

`source.unsplash.com/random` was deprecated by Unsplash in mid-2024 and the endpoint now returns HTTP 503 instead of an image. Browsers render a broken-image icon in place of the intended visual.

Verify in any shell:

```
curl -sI https://source.unsplash.com/random/800x600?office | head -1
# HTTP/1.1 503 Service Unavailable
```

#### What this PR changes

Replaces the deprecated counter-keyed random URL in the `SwrXstate` interactive demo so the SWR/XState walkthrough's images render again.

#### Replacement details

The seed includes the original `${counter++}` value so each SWR fetch still gets a distinct image (preserving the demo's intent). Same dimensions.

#### Background

I'm tracking the deprecated `source.unsplash.com/random` endpoint across public repos as part of [tteg](https://github.com/kiluazen/tteg), a tiny CLI/HTTP API I built so projects can drop in real Unsplash photos without registering an Unsplash app or managing API keys. tteg isn't introduced as a dependency by this PR — the diff is dependency-free `picsum.photos`. But if you want topic-matched real photos as a follow-up, the no-key HTTP API is at `https://tteg-api-53227342417.asia-south1.run.app/search?q=<query>&n=1` (CORS-on, no auth).

Research note covering ~16,500 files across ~885 unique repos that still hotlink the deprecated endpoint: <https://github.com/kiluazen/tteg/blob/research-note-autark/RESEARCH.md>.
